### PR TITLE
Avoid bug when importing oracles without Mujoco

### DIFF
--- a/design_bench/oracles/exact/__init__.py
+++ b/design_bench/oracles/exact/__init__.py
@@ -1,8 +1,39 @@
-from .hopper_controller_oracle import HopperControllerOracle
-from .ant_morphology_oracle import AntMorphologyOracle
-from .dkitty_morphology_oracle import DKittyMorphologyOracle
-from .toy_continuous_oracle import ToyContinuousOracle
-from .nas_bench_oracle import NASBenchOracle
-from .tf_bind_8_oracle import TFBind8Oracle
-from .tf_bind_10_oracle import TFBind10Oracle
-from .toy_discrete_oracle import ToyDiscreteOracle
+try:
+    from .hopper_controller_oracle import HopperControllerOracle
+except ImportError:
+    pass
+
+try:
+    from .ant_morphology_oracle import AntMorphologyOracle
+except ImportError:
+    pass
+
+try:
+    from .dkitty_morphology_oracle import DKittyMorphologyOracle
+except ImportError:
+    pass
+
+try:
+    from .toy_continuous_oracle import ToyContinuousOracle
+except ImportError:
+    pass
+
+try:
+    from .nas_bench_oracle import NASBenchOracle
+except ImportError:
+    pass
+
+try:
+    from .tf_bind_8_oracle import TFBind8Oracle
+except ImportError:
+    pass
+
+try:
+    from .tf_bind_10_oracle import TFBind10Oracle
+except ImportError:
+    pass
+
+try:
+    from .toy_discrete_oracle import ToyDiscreteOracle
+except ImportError:
+    pass


### PR DESCRIPTION
As per the PR, this avoids importing all oracles thus avoiding bugs as the following if we cannot install certain libraries (e.g. Mujoco)


```bash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/HDD/shared/Dev/design-baselines-private/design-bench/design_bench/oracles/exact/__init__.py", line 43, in <module>
    from .ant_morphology_oracle import AntMorphologyOracle
  File "/mnt/HDD/shared/Dev/design-baselines-private/design-bench/design_bench/oracles/exact/ant_morphology_oracle.py", line 1, in <module>
    from morphing_agents.mujoco.ant.env import MorphingAntEnv
ModuleNotFoundError: No module named 'morphing_agents'
```