### PR TITLE
Merging In Two Pull Requests

### DIFF
--- a/design_bench/datasets/dataset_builder.py
+++ b/design_bench/datasets/dataset_builder.py
@@ -453,7 +453,7 @@ class DatasetBuilder(abc.ABC):
         self._disable_transform = False
         self._disable_subsample = False
         self.dataset_visible_mask = np.full(
-            [self.dataset_size], True, dtype=np.bool)
+            [self.dataset_size], True, dtype=np.bool_)
 
         # handle requests to normalize and subsample the dataset
         if is_normalized_x:
@@ -1068,7 +1068,7 @@ class DatasetBuilder(abc.ABC):
             indices.size, max_samples, replace=False, p=probs / probs.sum())]
 
         # binary mask that determines which samples are visible
-        visible_mask = np.full([y.shape[0]], False, dtype=np.bool)
+        visible_mask = np.full([y.shape[0]], False, dtype=np.bool_)
         visible_mask[indices] = True
         self.dataset_visible_mask = visible_mask
         self.dataset_size = indices.size

--- a/design_bench/oracles/exact/__init__.py
+++ b/design_bench/oracles/exact/__init__.py
@@ -1,8 +1,39 @@
-from .hopper_controller_oracle import HopperControllerOracle
-from .ant_morphology_oracle import AntMorphologyOracle
-from .dkitty_morphology_oracle import DKittyMorphologyOracle
-from .toy_continuous_oracle import ToyContinuousOracle
-from .nas_bench_oracle import NASBenchOracle
-from .tf_bind_8_oracle import TFBind8Oracle
-from .tf_bind_10_oracle import TFBind10Oracle
-from .toy_discrete_oracle import ToyDiscreteOracle
+try:
+    from .hopper_controller_oracle import HopperControllerOracle
+except ImportError:
+    pass
+
+try:
+    from .ant_morphology_oracle import AntMorphologyOracle
+except ImportError:
+    pass
+
+try:
+    from .dkitty_morphology_oracle import DKittyMorphologyOracle
+except ImportError:
+    pass
+
+try:
+    from .toy_continuous_oracle import ToyContinuousOracle
+except ImportError:
+    pass
+
+try:
+    from .nas_bench_oracle import NASBenchOracle
+except ImportError:
+    pass
+
+try:
+    from .tf_bind_8_oracle import TFBind8Oracle
+except ImportError:
+    pass
+
+try:
+    from .tf_bind_10_oracle import TFBind10Oracle
+except ImportError:
+    pass
+
+try:
+    from .toy_discrete_oracle import ToyDiscreteOracle
+except ImportError:
+    pass

--- a/design_bench/oracles/exact/__init__.py
+++ b/design_bench/oracles/exact/__init__.py
@@ -1,39 +1,44 @@
 try:
-    from .hopper_controller_oracle import HopperControllerOracle
-except ImportError:
-    pass
+    from .ant_morphology_oracle import AntMorphologyOracle
+except ImportError as e:
+    print("Skipping AntMorphologyOracle import:", e)
 
 try:
-    from .ant_morphology_oracle import AntMorphologyOracle
-except ImportError:
-    pass
+    from .cifar_nas_oracle import CIFARNASOracle
+except ImportError as e:
+    print("Skipping CIFARNASOracle import:", e)
 
 try:
     from .dkitty_morphology_oracle import DKittyMorphologyOracle
-except ImportError:
-    pass
+except ImportError as e:
+    print("Skipping DKittyMorphologyOracle import:", e)
 
 try:
-    from .toy_continuous_oracle import ToyContinuousOracle
-except ImportError:
-    pass
+    from .hopper_controller_oracle import HopperControllerOracle
+except ImportError as e:
+    print("Skipping HopperControllerOracle import:", e)
 
 try:
     from .nas_bench_oracle import NASBenchOracle
-except ImportError:
-    pass
+except ImportError as e:
+    print("Skipping NASBenchOracle import:", e)
 
 try:
     from .tf_bind_8_oracle import TFBind8Oracle
-except ImportError:
-    pass
+except ImportError as e:
+    print("Skipping TFBind8Oracle import:", e)
 
 try:
     from .tf_bind_10_oracle import TFBind10Oracle
-except ImportError:
-    pass
+except ImportError as e:
+    print("Skipping TFBind10Oracle import:", e)
+
+try:
+    from .toy_continuous_oracle import ToyContinuousOracle
+except ImportError as e:
+    print("Skipping ToyContinuousOracle import:", e)
 
 try:
     from .toy_discrete_oracle import ToyDiscreteOracle
-except ImportError:
-    pass
+except ImportError as e:
+    print("Skipping ToyDiscreteOracle import:", e)


### PR DESCRIPTION
This merge includes changes from:

https://github.com/brandontrabucco/design-bench/pull/12

and 

https://github.com/brandontrabucco/design-bench/pull/13.

The included changes allow design-bench to import correctly when certain components are not installed, such as `MuJoCo` when robotics MBO tasks are not needed in your installation. Second, support for modern numpy versions is added by accommodating a change in how numpy refers to the boolean dtype.